### PR TITLE
fix: rename Create Course Repository functions

### DIFF
--- a/06-different-approaches/1-functional/src/modules/courses/infrastructure/ApiCourseRepository.ts
+++ b/06-different-approaches/1-functional/src/modules/courses/infrastructure/ApiCourseRepository.ts
@@ -1,7 +1,7 @@
 import { Course } from "../domain/Course";
 import { CourseRepository } from "../domain/CourseRepository";
 
-export function createLocalStorageCourseRepository(): CourseRepository {
+export function createApiCourseRepository(): CourseRepository {
 	return {
 		save,
 		get,

--- a/06-different-approaches/3-value-objects/functional/src/modules/courses/infrastructure/ApiCourseRepository.ts
+++ b/06-different-approaches/3-value-objects/functional/src/modules/courses/infrastructure/ApiCourseRepository.ts
@@ -1,7 +1,7 @@
 import { Course } from "../domain/Course";
 import { CourseRepository } from "../domain/CourseRepository";
 
-export function createLocalStorageCourseRepository(): CourseRepository {
+export function createApiCourseRepository(): CourseRepository {
 	return {
 		save,
 		get,


### PR DESCRIPTION
Bugfix: Changed the function `createLocalStorageCourseRepository` for `createApiCourseRepository` in `ApiCourseRepository.ts` files.