### PR TITLE
fix: rename use case to `getAllLocations`

### DIFF
--- a/07-next-steps/1-more-examples/maps/src/modules/locations/application/getAllLocations.ts
+++ b/07-next-steps/1-more-examples/maps/src/modules/locations/application/getAllLocations.ts
@@ -1,6 +1,6 @@
 import { Location } from "../domain/Location";
 import { LocationRepository } from "../domain/LocationRepository";
 
-export async function getAllCourses(locationRepository: LocationRepository): Promise<Location[]> {
+export async function getAllLocations(locationRepository: LocationRepository): Promise<Location[]> {
 	return locationRepository.getAll();
 }


### PR DESCRIPTION
Fix bad naming of the function's use case.